### PR TITLE
Fixing "project" data reference in module

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -86,6 +86,7 @@ app_server <- function(input, output, session) {
 
   mod_living_situation_server(
     id = "living_situation_1",
+    project_data = dm$project,
     enrollment_data = dm$enrollment,
     exit_data = dm$exit,
     clients_filtered = clients_filtered,

--- a/R/mod_living_situation.R
+++ b/R/mod_living_situation.R
@@ -140,7 +140,7 @@ mod_living_situation_ui <- function(id){
 #' living_situation Server Functions
 #'
 #' @noRd
-mod_living_situation_server <- function(id, enrollment_data, exit_data, clients_filtered, rctv){
+mod_living_situation_server <- function(id, project_data, enrollment_data, exit_data, clients_filtered, rctv){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
 
@@ -157,7 +157,7 @@ mod_living_situation_server <- function(id, enrollment_data, exit_data, clients_
 
       shiny::req(rctv$selected_projects)
 
-      project_ids <- dm$project |>
+      project_ids <- project_data |>
         dplyr::filter(project_name %in% rctv$selected_projects) |>
         dplyr::pull(project_id)
 


### PR DESCRIPTION
After deployment earlier today, I noticed the "Living Situation" page was throwing errors in the live version of the app.

Upon review, I realized that I had been referencing an object in `R/mod_living_situation.R` that wasn't available to the module.  This has been corrected in this PR, and tested locally.