### PR TITLE
Issue 32 household head filter

### DIFF
--- a/R/mod_filters.R
+++ b/R/mod_filters.R
@@ -237,11 +237,23 @@ mod_filters_server <- function(id, dm, w, rctv){
 
       }
 
+      # Filter head of household using enrollment data
+      if (input$heads_of_household_global == TRUE) {
+
+        enrollment <- dm$enrollment |>
+          dplyr::filter(relationship_to_ho_h == "Self (head of household)")
+
+      } else {
+
+        enrollment <- dm$enrollment
+
+      }
+
       out <- dm$project |>
         dplyr::filter(project_name %in% input$project_filter_global) |>
         dplyr::select(project_id) |>
         dplyr::inner_join(
-          dm$enrollment |>
+          enrollment |>
             # Remove individuals who entered *after* the later active date
             dplyr::filter(
               entry_date <= input$active_date_filter_global[2]

--- a/R/mod_filters.R
+++ b/R/mod_filters.R
@@ -95,6 +95,13 @@ mod_filters_ui <- function(id){
           value = TRUE
         ),
 
+        # Heads of household checkbox
+        shiny::checkboxInput(
+          inputId = ns("heads_of_household_global"),
+          label = "Limit to Heads of Household",
+          value = FALSE
+        ),
+
         # Action button to apply filters
         bs4Dash::actionButton(
           inputId = ns("apply_filters"),


### PR DESCRIPTION
A new filter is added in the right-hand global filters pane.

This filter allows users to see data that refers only to heads of households.

To apply these changes in the server I defined a new `enrollment` object before the processing pipe (similar to what was implemented for `clients`) which filters `dm$enrollment` based on the value of the checkbox. Later, I use this object instead of `dm$enrollment`.