### PR TITLE
issue 36 improve icons in infoboxes

### DIFF
--- a/R/mod_disabilities.R
+++ b/R/mod_disabilities.R
@@ -218,7 +218,7 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("user")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -229,7 +229,7 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_disabilities_data(),
         subtitle = "Total # of Youth with Disabilities Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -252,7 +252,7 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_no_disabilities(),
         subtitle = "Total # of Youth with No Disabilities or Substance Use",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })

--- a/R/mod_disabilities.R
+++ b/R/mod_disabilities.R
@@ -229,7 +229,7 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_disabilities_data(),
         subtitle = "Total # of Youth with Disabilities Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("accessible-icon")
       )
 
     })
@@ -252,7 +252,7 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_no_disabilities(),
         subtitle = "Total # of Youth with No Disabilities or Substance Use",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("accessible-icon")
       )
 
     })

--- a/R/mod_domestic_violence.R
+++ b/R/mod_domestic_violence.R
@@ -262,7 +262,7 @@ mod_domestic_violence_server <- function(id, domestic_violence_data, clients_fil
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("user")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -273,7 +273,7 @@ mod_domestic_violence_server <- function(id, domestic_violence_data, clients_fil
       bs4Dash::bs4ValueBox(
         value = n_youth_with_domestic_violence_data(),
         subtitle = "Total # of Youth with Domestic Violence Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })

--- a/R/mod_domestic_violence.R
+++ b/R/mod_domestic_violence.R
@@ -273,7 +273,7 @@ mod_domestic_violence_server <- function(id, domestic_violence_data, clients_fil
       bs4Dash::bs4ValueBox(
         value = n_youth_with_domestic_violence_data(),
         subtitle = "Total # of Youth with Domestic Violence Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("user-shield")
       )
 
     })

--- a/R/mod_education.R
+++ b/R/mod_education.R
@@ -223,7 +223,7 @@ mod_education_server <- function(id, education_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_education_data(),
         subtitle = "Total # of Youth with Education Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("book-open")
       )
 
     })

--- a/R/mod_education.R
+++ b/R/mod_education.R
@@ -212,7 +212,7 @@ mod_education_server <- function(id, education_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("user")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -223,7 +223,7 @@ mod_education_server <- function(id, education_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_education_data(),
         subtitle = "Total # of Youth with Education Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })

--- a/R/mod_employment.R
+++ b/R/mod_employment.R
@@ -165,7 +165,7 @@ mod_employment_server <- function(id, employment_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("user")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -176,7 +176,7 @@ mod_employment_server <- function(id, employment_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_employment_data(),
         subtitle = "Total # of Youth with Employment Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })

--- a/R/mod_employment.R
+++ b/R/mod_employment.R
@@ -176,7 +176,7 @@ mod_employment_server <- function(id, employment_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_employment_data(),
         subtitle = "Total # of Youth with Employment Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("briefcase")
       )
 
     })

--- a/R/mod_exit.R
+++ b/R/mod_exit.R
@@ -186,7 +186,7 @@ mod_exit_server <- function(id, exit_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_exit_data(),
         subtitle = "Total # of Youth with Exit Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("door-open")
       )
 
     })

--- a/R/mod_exit.R
+++ b/R/mod_exit.R
@@ -175,7 +175,7 @@ mod_exit_server <- function(id, exit_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("user")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -186,7 +186,7 @@ mod_exit_server <- function(id, exit_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_exit_data(),
         subtitle = "Total # of Youth with Exit Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })

--- a/R/mod_health.R
+++ b/R/mod_health.R
@@ -340,7 +340,7 @@ mod_health_server <- function(id, health_data, counseling_data, clients_filtered
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("user")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -351,7 +351,7 @@ mod_health_server <- function(id, health_data, counseling_data, clients_filtered
       bs4Dash::bs4ValueBox(
         value = n_youth_with_health_data(),
         subtitle = "Total # of Youth with Health Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -362,7 +362,7 @@ mod_health_server <- function(id, health_data, counseling_data, clients_filtered
       bs4Dash::bs4ValueBox(
         value = n_youth_with_counseling_data(),
         subtitle = "Total # of Youth with Counseling Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })

--- a/R/mod_health.R
+++ b/R/mod_health.R
@@ -351,7 +351,7 @@ mod_health_server <- function(id, health_data, counseling_data, clients_filtered
       bs4Dash::bs4ValueBox(
         value = n_youth_with_health_data(),
         subtitle = "Total # of Youth with Health Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("stethoscope")
       )
 
     })
@@ -362,7 +362,7 @@ mod_health_server <- function(id, health_data, counseling_data, clients_filtered
       bs4Dash::bs4ValueBox(
         value = n_youth_with_counseling_data(),
         subtitle = "Total # of Youth with Counseling Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("stethoscope")
       )
 
     })

--- a/R/mod_income_benefits.R
+++ b/R/mod_income_benefits.R
@@ -367,7 +367,7 @@ mod_income_benefits_server <- function(id, income_data, benefits_data, clients_f
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("user")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     )
@@ -378,7 +378,7 @@ mod_income_benefits_server <- function(id, income_data, benefits_data, clients_f
       bs4Dash::bs4ValueBox(
         value = n_youth_with_income_data(),
         subtitle = "Total # of Youth with Income Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     )
@@ -389,7 +389,7 @@ mod_income_benefits_server <- function(id, income_data, benefits_data, clients_f
       bs4Dash::bs4ValueBox(
         value = n_youth_with_benefits_data(),
         subtitle = "Total # of Youth with Benefits Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     )

--- a/R/mod_income_benefits.R
+++ b/R/mod_income_benefits.R
@@ -378,7 +378,7 @@ mod_income_benefits_server <- function(id, income_data, benefits_data, clients_f
       bs4Dash::bs4ValueBox(
         value = n_youth_with_income_data(),
         subtitle = "Total # of Youth with Income Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("dollar-sign")
       )
 
     )
@@ -389,7 +389,7 @@ mod_income_benefits_server <- function(id, income_data, benefits_data, clients_f
       bs4Dash::bs4ValueBox(
         value = n_youth_with_benefits_data(),
         subtitle = "Total # of Youth with Benefits Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("dollar-sign")
       )
 
     )

--- a/R/mod_living_situation.R
+++ b/R/mod_living_situation.R
@@ -216,7 +216,7 @@ mod_living_situation_server <- function(id, project_data, enrollment_data, exit_
       bs4Dash::bs4ValueBox(
         value = n_youth_with_living_data(),
         subtitle = "Total # of Youth with Living Situation Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("bed")
       )
 
     })

--- a/R/mod_living_situation.R
+++ b/R/mod_living_situation.R
@@ -205,7 +205,7 @@ mod_living_situation_server <- function(id, project_data, enrollment_data, exit_
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("user")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -216,7 +216,7 @@ mod_living_situation_server <- function(id, project_data, enrollment_data, exit_
       bs4Dash::bs4ValueBox(
         value = n_youth_with_living_data(),
         subtitle = "Total # of Youth with Living Situation Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })

--- a/R/mod_parenting.R
+++ b/R/mod_parenting.R
@@ -200,7 +200,7 @@ mod_parenting_server <- function(id, health_data, enrollment_data, clients_filte
       bs4Dash::bs4ValueBox(
         value = n_youth_with_pregnancy_data(),
         subtitle = "Total # of Youth with Pregnancy Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("baby-carriage")
       )
 
     )
@@ -211,7 +211,7 @@ mod_parenting_server <- function(id, health_data, enrollment_data, clients_filte
       bs4Dash::bs4ValueBox(
         value = n_youth_with_parenting_data(),
         subtitle = "Total # of Youth with Parenting Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("baby-carriage")
       )
 
     )

--- a/R/mod_parenting.R
+++ b/R/mod_parenting.R
@@ -189,7 +189,7 @@ mod_parenting_server <- function(id, health_data, enrollment_data, clients_filte
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("users")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     )
@@ -199,7 +199,8 @@ mod_parenting_server <- function(id, health_data, enrollment_data, clients_filte
 
       bs4Dash::bs4ValueBox(
         value = n_youth_with_pregnancy_data(),
-        subtitle = "Total # of Youth with Pregnancy Data Available"
+        subtitle = "Total # of Youth with Pregnancy Data Available",
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     )
@@ -209,7 +210,8 @@ mod_parenting_server <- function(id, health_data, enrollment_data, clients_filte
 
       bs4Dash::bs4ValueBox(
         value = n_youth_with_parenting_data(),
-        subtitle = "Total # of Youth with Parenting Data Available"
+        subtitle = "Total # of Youth with Parenting Data Available",
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     )

--- a/R/mod_services.R
+++ b/R/mod_services.R
@@ -207,7 +207,7 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
       bs4Dash::bs4ValueBox(
         value = n_youth_with_services_data(),
         subtitle = "Total # of Youth with Services Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("hands-helping")
       )
 
     })
@@ -218,7 +218,7 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
       bs4Dash::bs4ValueBox(
         value = n_youth_with_referral_data(),
         subtitle = "Total # of Youth with Referral Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("hands-helping")
       )
 
     })

--- a/R/mod_services.R
+++ b/R/mod_services.R
@@ -196,7 +196,7 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("user")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -207,7 +207,7 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
       bs4Dash::bs4ValueBox(
         value = n_youth_with_services_data(),
         subtitle = "Total # of Youth with Services Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
@@ -218,7 +218,7 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
       bs4Dash::bs4ValueBox(
         value = n_youth_with_referral_data(),
         subtitle = "Total # of Youth with Referral Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     })

--- a/R/mod_trafficking.R
+++ b/R/mod_trafficking.R
@@ -276,7 +276,7 @@ mod_trafficking_server <- function(id, trafficking_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_sex_data(),
         subtitle = "Total # of Youth with Sex Trafficking Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("exclamation-circle")
       )
 
     )
@@ -287,7 +287,7 @@ mod_trafficking_server <- function(id, trafficking_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_labor_data(),
         subtitle = "Total # of Youth with Labor Trafficking Data Available",
-        icon = shiny::icon("user", class = "fa-solid")
+        icon = shiny::icon("exclamation-circle")
       )
 
     )

--- a/R/mod_trafficking.R
+++ b/R/mod_trafficking.R
@@ -265,7 +265,7 @@ mod_trafficking_server <- function(id, trafficking_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth(),
         subtitle = "Total # of Youth in Program(s)",
-        icon = shiny::icon("user")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     )
@@ -276,7 +276,7 @@ mod_trafficking_server <- function(id, trafficking_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_sex_data(),
         subtitle = "Total # of Youth with Sex Trafficking Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     )
@@ -287,7 +287,7 @@ mod_trafficking_server <- function(id, trafficking_data, clients_filtered){
       bs4Dash::bs4ValueBox(
         value = n_youth_with_labor_data(),
         subtitle = "Total # of Youth with Labor Trafficking Data Available",
-        icon = shiny::icon("home")
+        icon = shiny::icon("user", class = "fa-solid")
       )
 
     )


### PR DESCRIPTION
Infoboxes used across the app represent the total number of youth with particular data available (for example: total number of youth with disabilities data available or total number of youth with services data available).

As these infoboxes refer to an amount of persons, it was decided to use the "user" icon from font-awesome library. In addition, the solid class was added because it looked better: 

![image](https://github.com/COHHIO/ryha/assets/60263844/a5f52365-0ebc-449a-90a8-20aed2bc464e)

Other alternatives considered but not pursued are listed below:
- Replace "user" icon with other icons, such as:
    - ![image](https://github.com/COHHIO/ryha/assets/60263844/05900f5c-64df-4354-9f29-169a7a21757d) Similar to user, but it gives more the idea of a "male", so it was discarded.
    - ![image](https://github.com/COHHIO/ryha/assets/60263844/0378f22b-5184-42bc-af30-0713717b79f1) These two don't seem to look well in the app compared to the chosen "user".
    - ![image](https://github.com/COHHIO/ryha/assets/60263844/dbddc3fe-a99d-4da7-a85d-fe41963fce0f) A single user looked better that multiple.
    - ![image](https://github.com/COHHIO/ryha/assets/60263844/9a506a24-a4b4-45af-8478-d6d690efa61d) Discarded because it assumes two genders.
- Use "user" icon for "Total # of Youth in Program(s)" infobox and the same icon used in the left-sidebar for the remaining boxes (for example, in Disabilities page, use "accessible-icon" for "Total # of Youth with Disabilities Data Available" and "Total # of Youth with No Disabilities or Substance Use"). This approach was discarded because it could be confusing to see the same icon in boxes that mean the opposite.
- Use an icon that best represents the box and no icon if a good representation of the box label can't be found. This approach was discarded because mixing boxes with and without icons in a page didn't look good.
- Remove all icons. This approach was discarded because boxes without icons didn't look good.

Regarding implementation, the `fa-solid` class was added to each call of `shiny::icon()`. The following function could be used to extract this logic, but we are not sure if it makes sense to create it:
```
#' Create a solid font-awesome icon
#'
#' @param name The name of the icon (from font-awesome library).
#' The \code{"fa-"} prefix should not appear in the name.
#'
#' @return An <i> (icon) HTML tag with \code{fa-solid} class
fa_icon_solid <- function(name) {
  shiny::icon(name, class = "fa-solid")
}
```

