### PR TITLE
Issue 37 extra whitespace after apostrophes in chart labels legends

### DIFF
--- a/R/mod_living_situation.R
+++ b/R/mod_living_situation.R
@@ -189,7 +189,7 @@ mod_living_situation_server <- function(id, project_data, enrollment_data, exit_
           !living_situation %in% c(
             "No exit interview completed",
             "Worker unable to determine",
-            "Client doesn’t know",
+            "Client doesn't know",
             "Client refused",
             "Data not collected"
           )
@@ -421,7 +421,7 @@ mod_living_situation_server <- function(id, project_data, enrollment_data, exit_
           living_situation %in% c(
             "No exit interview completed",
             "Worker unable to determine",
-            "Client doesn’t know",
+            "Client doesn't know",
             "Client refused",
             "Data not collected",
             "(Blank)"
@@ -451,7 +451,7 @@ mod_living_situation_server <- function(id, project_data, enrollment_data, exit_
           destination %in% c(
             "No exit interview completed",
             "Worker unable to determine",
-            "Client doesn’t know",
+            "Client doesn't know",
             "Client refused",
             "Data not collected",
             "(Blank)"

--- a/R/mod_parenting.R
+++ b/R/mod_parenting.R
@@ -313,7 +313,7 @@ mod_parenting_server <- function(id, health_data, enrollment_data, clients_filte
     parenting_data <- shiny::reactive({
 
       hhs_with_children <- enrollment_data_filtered() |>
-        dplyr::filter(relationship_to_ho_h == "Head of household’s child") |>
+        dplyr::filter(relationship_to_ho_h == "Head of household's child") |>
         dplyr::distinct(household_id) |>
         dplyr::pull()
 
@@ -322,7 +322,7 @@ mod_parenting_server <- function(id, health_data, enrollment_data, clients_filte
           household_id %in% hhs_with_children,
           relationship_to_ho_h %in% c(
             "Self (head of household)",
-            "Head of household’s spouse or partner"
+            "Head of household's spouse or partner"
           )
         ) |>
         dplyr::count(relationship_to_ho_h, name = "Count", sort = TRUE) |>

--- a/R/mod_trafficking.R
+++ b/R/mod_trafficking.R
@@ -393,7 +393,7 @@ mod_trafficking_server <- function(id, trafficking_data, clients_filtered){
       out <- trafficking_data_filtered() |>
         dplyr::filter(
           !count_of_exchange_for_sex %in% c(
-            "Client doesn’t know",
+            "Client doesn't know",
             "Client refused",
             "Data not collected"
           ),

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ set, for the purposes of interacting with the external database:
   to/from the database (stored at the root of the directory, needed for
   *writing to* the database)
 
-After installing the package, you can launch the app using the package’s
+After installing the package, you can launch the app using the package's
 `run_app()` function.
 
 ``` r
@@ -57,7 +57,7 @@ format compliant with the *HMIS Data Standards*. This data originates
 from one of a few separate HMIS databases in the State. The HMIS
 databases have the capability to query the database and export a .zip
 file. This .zip file can be uploaded into the **COHHIO Youth Data
-Dashboard** app via the app’s “*Upload*” page.
+Dashboard** app via the app's “*Upload*” page.
 
 ### Requirements
 

--- a/data-raw/DisabilityCodes.R
+++ b/data-raw/DisabilityCodes.R
@@ -17,7 +17,7 @@ SubstanceUseDisorderCodes <- tibble::tribble(
   1L, "Alcohol use disorder",
   2L, "Drug use disorder",
   3L, "Both alcohol and drug use disorders",
-  8L, "Client doesn’t know",
+  8L, "Client doesn't know",
   9L, "Client refused",
   99L, "Data not collected"
 )

--- a/data-raw/EnrollmentCodes.R
+++ b/data-raw/EnrollmentCodes.R
@@ -4,9 +4,9 @@
 RelationshipToHoHCodes <- tibble::tribble(
   ~Code, ~Description,
   1L, "Self (head of household)",
-  2L, "Head of household’s child",
-  3L, "Head of household’s spouse or partner",
-  4L, "Head of household’s other relation member",
+  2L, "Head of household's child",
+  3L, "Head of household's spouse or partner",
+  4L, "Head of household's other relation member",
   5L, "Other: non-relation member",
   99L, "Data not collected"
 )
@@ -17,7 +17,7 @@ LengthOfStayCodes <- tibble::tribble(
   3L, "One month or more, but less than 90 days",
   4L, "90 days or more but less than one year",
   5L, "One year or longer",
-  8L, "Client doesn’t know",
+  8L, "Client doesn't know",
   9L, "Client refused",
   10L, "One night or less",
   11L, "Two to six nights",
@@ -30,14 +30,14 @@ TimesHomelessPastThreeYearsCodes <- tibble::tribble(
   2L, "Two times",
   3L, "Three times",
   4L, "Four or more times",
-  8L, "Client doesn’t know",
+  8L, "Client doesn't know",
   9L, "Client refused",
   99L, "Data not collected"
 )
 
 MonthsHomelessPastThreeYearsCodes <- tibble::tribble(
   ~Code, ~Description,
-  8L, "Client doesn’t know",
+  8L, "Client doesn't know",
   9L, "Client refused",
   99L, "Data not collected",
   101L, "1 month",
@@ -69,7 +69,7 @@ ReferralSourceCodes <- tibble::tribble(
   37L, "Mental Hospital",
   38L, "School",
   39L, "Other Organization",
-  8L, "Client doesn’t know",
+  8L, "Client doesn't know",
   9L, "Client refused",
   99L, "Data not collected"
 )
@@ -82,7 +82,7 @@ SexualOrientationCodes <- tibble::tribble(
   4L, "Bisexual",
   5L, "Questioning / unsure",
   6L, "Other",
-  8L, "Client doesn’t know",
+  8L, "Client doesn't know",
   9L, "Client refused",
   99L, "Data not collected"
 )

--- a/data-raw/ExitCodes.R
+++ b/data-raw/ExitCodes.R
@@ -13,7 +13,7 @@ CountExchangeForSexCodes <- tibble::tribble(
   2L, "4-7",
   3L, "8-11",
   4L, "12 or more",
-  8L, "Client doesn’t know",
+  8L, "Client doesn't know",
   9L, "Client refused",
   99L, "Data not collected"
 )

--- a/data-raw/HealthAndDVCodes.R
+++ b/data-raw/HealthAndDVCodes.R
@@ -8,7 +8,7 @@ HealthStatusCodes <- tibble::tribble(
   3L, "Good",
   4L, "Fair",
   5L, "Poor",
-  8L, "Client doesn’t know",
+  8L, "Client doesn't know",
   9L, "Client refused",
   99L, "Data not collected"
 )
@@ -22,7 +22,7 @@ WhenDVOccurredCodes <- tibble::tribble(
   2L, "Three to six months ago (excluding six months exactly)",
   3L, "Six months to one year ago (excluding one year exactly)",
   4L, "One year ago, or more",
-  8L, "Client doesn’t know",
+  8L, "Client doesn't know",
   9L, "Client refused",
   99L, "Data not collected"
 )

--- a/data-raw/LivingCodes.R
+++ b/data-raw/LivingCodes.R
@@ -16,10 +16,10 @@ LivingCodes <- tibble::tribble(
   2L, "Transitional housing for homeless persons (including homeless youth)", "Homeless", "Temporary",
   32L, "Host Home (non-crisis)", "Temporary", "Temporary",
   13L, "Staying or living with friends, temporary tenure (e.g. room apartment or house)", "Temporary", "Temporary",
-  36L, "Staying or living in a friend’s room, apartment or house", "Not enough data", "Not enough data",
+  36L, "Staying or living in a friend's room, apartment or house", "Not enough data", "Not enough data",
   12L, "Staying or living with family, temporary tenure (e.g. room, apartment or house)", "Temporary", "Temporary",
   22L, "Staying or living with family, permanent tenure", "Permanent", "Permanent",
-  35L, "Staying or living in a family member’s room, apartment or house", "Not enough data", "Not enough data",
+  35L, "Staying or living in a family member's room, apartment or house", "Not enough data", "Not enough data",
   23L, "Staying or living with friends, permanent tenure", "Permanent", "Permanent",
   26L, "Moved from one HOPWA funded project to HOPWA PH", "Permanent", "Permanent",
   27L, "Moved from one HOPWA funded project to HOPWA TH", "Homeless", "Temporary",
@@ -37,7 +37,7 @@ LivingCodes <- tibble::tribble(
   17L, "Other", "Not enough data", "Not enough data",
   24, "Deceased", "Not enough data", "Not enough data",
   37L, "Worker unable to determine", "Not enough data", "Not enough data",
-  8L, "Client doesn’t know", "Not enough data", "Not enough data",
+  8L, "Client doesn't know", "Not enough data", "Not enough data",
   9L, "Client refused", "Not enough data", "Not enough data",
   99L, "Data not collected", "Not enough data", "Not enough data"
 )

--- a/inst/app/www/welcome_text.md
+++ b/inst/app/www/welcome_text.md
@@ -10,7 +10,7 @@ This app is the result of a partnership between the [Ohio Department of Health (
   </p>
 </div>
 
-As part of ODH’s youth homelessness grant program, COHHIO was contracted to assist the department in program development using data-driven approaches. COHHIO supported the department in establishing data collection requirements and providing technical assistance to sub-recipients to standardize data collection across the program. This was best accomplished using the Housing and Urban Development (HUD)-required Homeless Management Information System (HMIS).
+As part of ODH's youth homelessness grant program, COHHIO was contracted to assist the department in program development using data-driven approaches. COHHIO supported the department in establishing data collection requirements and providing technical assistance to sub-recipients to standardize data collection across the program. This was best accomplished using the Housing and Urban Development (HUD)-required Homeless Management Information System (HMIS).
 
 In 2022, COHHIO entered into a contract with [Ketchbrook Analytics](https://www.ketchbrookanalytics.com) to assist by analyzing large volumes of data from sub-grantees and quantifying trends across data sets.
 


### PR DESCRIPTION
The problem was caused by the use of `’` as an apostrophe. It seems that `’` gets pasted when copying an apostrophe from a PDF.

To solve the issue, I replaced all occurrences of `’` with `'`. This should solve issues across the app. 

In the future, we should be careful if new codes with apostrophes are integrated to the app. We need to make sure that `'` is used instead of `’`.
