### PR TITLE
Issue 70 disable upload when no file

### DIFF
--- a/R/mod_upload.R
+++ b/R/mod_upload.R
@@ -100,7 +100,7 @@ mod_upload_server <- function(id){
 
     shiny::observe({
 
-      if (is.null(input$upload_pwd) || input$upload_pwd != Sys.getenv("UPLOAD_PWD")) {
+      if (is.null(input$upload_pwd) || input$upload_pwd != Sys.getenv("UPLOAD_PWD") || is.null(input$choose_zip$datapath)) {
 
         shinyjs::disable(id = "upload_btn")
 


### PR DESCRIPTION
With this small change, the UPLOAD button will be disabled if no file has been selected (even if password is correct).