### PR TITLE
Issue 83 changes to disabilities page

### DIFF
--- a/R/mod_disabilities.R
+++ b/R/mod_disabilities.R
@@ -22,7 +22,8 @@ mod_disabilities_ui <- function(id){
         # regardless of data quality (youth with data not collected in all
         # disability columns is still counted here)
         bs4Dash::bs4ValueBoxOutput(
-          outputId = ns("n_youth_in_disability_data_box"),
+          outputId = ns("n_youth_box"),
+          # outputId = ns("n_youth_in_disability_data_box"),
           width = "100%"
         )
       ),
@@ -177,14 +178,16 @@ mod_disabilities_ui <- function(id){
           height = DEFAULT_BOX_HEIGHT,
           maximizable = TRUE,
 
-          shiny::tabPanel(
-            title = "Summary",
-            shiny::htmlOutput(ns("data_quality_string")),
-          ),
+          # shiny::tabPanel(
+          #   title = "Summary",
+          #   shiny::htmlOutput(ns("data_quality_string")),
+          # ),
 
           shiny::tabPanel(
             title = "Youth by Number of Answers Missing",
-            reactable::reactableOutput(outputId = ns("missingness_stats_tbl1"))
+            reactable::reactableOutput(outputId = ns("missingness_stats_tbl1")),
+            shiny::br(),
+            shiny::em("Note: \"Missing\" is defined as \"Client doesn't know\", \"Client prefers not to answer\", \"Data not collected\", or blank.")
           ),
 
           shiny::tabPanel(
@@ -212,6 +215,17 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
 
       clients_filtered() |>
         nrow()
+
+    })
+
+    # Render number of clients box
+    output$n_youth_box <- bs4Dash::renderbs4ValueBox({
+
+      bs4Dash::bs4ValueBox(
+        value = n_youth(),
+        subtitle = "Total # of Youth in Program(s)",
+        icon = shiny::icon("user", class = "fa-solid")
+      )
 
     })
 
@@ -250,6 +264,9 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
 
     })
 
+    # TODO // Implement these "improved" counts across the first infoBox for
+    # all pages
+
     n_youth_in_disability_data <- reactive({
 
       disabilities_data_filtered() |>
@@ -258,16 +275,16 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
 
     })
 
-    # Render number of youth in disabilities data
-    output$n_youth_in_disability_data_box <- bs4Dash::renderbs4ValueBox({
-
-      bs4Dash::bs4ValueBox(
-        value = n_youth_in_disability_data(),
-        subtitle = "Total # of Youth in Disabilities Data",
-        icon = shiny::icon("user", class = "fa-solid")
-      )
-
-    })
+    # # Render number of youth in disabilities data
+    # output$n_youth_in_disability_data_box <- bs4Dash::renderbs4ValueBox({
+    #
+    #   bs4Dash::bs4ValueBox(
+    #     value = n_youth_in_disability_data(),
+    #     subtitle = "Total # of Youth in Disabilities Data",
+    #     icon = shiny::icon("user", class = "fa-solid")
+    #   )
+    #
+    # })
 
     # Total number of youth with disabilities or substance use
     n_youth_with_disabilities_or_substance_use <- shiny::reactive({
@@ -738,13 +755,13 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
     })
 
     # Missingness Statistics ----
-    output$data_quality_string <- shiny::renderUI({
-      glue::glue(
-        "<strong>{round(n_youth_in_disability_data()/n_youth(), 2) * 100}%</strong>
-        of youth in selected program(s) have entries in Disabilities Data."
-      ) |>
-        shiny::HTML()
-    })
+    # output$data_quality_string <- shiny::renderUI({
+    #   glue::glue(
+    #     "<strong>{round(n_youth_in_disability_data()/n_youth(), 2) * 100}%</strong>
+    #     of youth in selected program(s) have entries in Disabilities Data."
+    #   ) |>
+    #     shiny::HTML()
+    # })
 
     output$missingness_stats_tbl1 <- reactable::renderReactable(
 

--- a/R/mod_disabilities.R
+++ b/R/mod_disabilities.R
@@ -17,27 +17,36 @@ mod_disabilities_ui <- function(id){
 
       shiny::column(
         width = 4,
-        # Number of clients (post filters)
+        # Number of youth in disabilities data (post filters)
+        # This number corresponds to the number of youth in disability table,
+        # regardless of data quality (youth with data not collected in all
+        # disability columns is still counted here)
         bs4Dash::bs4ValueBoxOutput(
-          outputId = ns("n_youth_box"),
+          outputId = ns("n_youth_in_disability_data_box"),
           width = "100%"
         )
       ),
 
       shiny::column(
         width = 4,
-        # Number of projects (post filters)
+        # Number of youth with disabilities or substance use (post filters)
+        # This number corresponds to youth that have a value of "Yes" in one
+        # of the columns that refer to disabilities or substance use. In case
+        # the youth has multiple entries, the most recent value will be used.
         bs4Dash::bs4ValueBoxOutput(
-          outputId = ns("n_youth_with_disabilities_data_box"),
+          outputId = ns("n_youth_with_disabilities_or_substance_use_box"),
           width = "100%"
         )
       ),
 
       shiny::column(
         width = 4,
-        # Number of youth with no disabilities
+        # Number of youth that did not inform any disabilities or substance use (post filters)
+        # The wording here is made on purpose to include both "No" and missing answers.
+        # In other words, we are counting all youth without a "Yes" value, regardless
+        # of missing data
         bs4Dash::bs4ValueBoxOutput(
-          outputId = ns("n_youth_with_no_disabilities_box"),
+          outputId = ns("n_youth_without_disabilities_or_substance_use_box"),
           width = "100%"
         )
       )
@@ -46,7 +55,7 @@ mod_disabilities_ui <- function(id){
 
     shiny::hr(),
 
-    # Pie Charts ----
+    # Charts ----
 
     shiny::fluidRow(
 
@@ -54,12 +63,12 @@ mod_disabilities_ui <- function(id){
         width = 6,
 
         bs4Dash::box(
-          title = "# of Youth with Disabilities by Type",
+          title = "Disability Prevalence in Youth",
           width = NULL,
           height = DEFAULT_BOX_HEIGHT,
           maximizable = TRUE,
           echarts4r::echarts4rOutput(
-            outputId = ns("disabilities_pie_chart"),
+            outputId = ns("disabilities_chart"),
             height = "100%"
           )
         )
@@ -182,7 +191,7 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
 
-    # Total number of Youth in program(s), based on `client.csv` file
+    # Total number of youth in program(s), based on `client.csv` file
     n_youth <- shiny::reactive({
 
       clients_filtered() |>
@@ -201,121 +210,167 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
 
     })
 
-    # Total number of Youth in program(s) that exist in the `disabilities.csv`
-    # file
-    n_youth_with_disabilities_data <- shiny::reactive(
+    # Subset most recent data for each youth
+    disabilities_data_recent <- shiny::reactive({
 
       disabilities_data_filtered() |>
-        dplyr::filter(
-          disability_response %in% c(
-            "Yes", "No", SubstanceUseDisorderCodes$Description[2:4]
-          )
-        ) |>
-        dplyr::distinct(personal_id, organization_id) |>
-        nrow()
+        # Unique key to identify a youth
+        dplyr::group_by(personal_id, organization_id) |>
+        # Keep the values that correspond to the last date_updated
+        dplyr::filter(date_updated == max(date_updated)) |>
+        # Required ungroup step
+        dplyr::ungroup() |>
+        # Convert data to have one row per youth
+        tidyr::pivot_wider(names_from = disability_type, values_from = disability_response) |>
+        # Sometimes, "Project start" and "Project exit" have the same date_updated value
+        # For that reason, we can still find duplicated youth
+        # In this scenario, we will keep "Project exit" row. The trick is to arrange the rows
+        # and keep the first row per client (as "exit" will show before "start" in the sorting)
+        dplyr::arrange(organization_id, personal_id, data_collection_stage) |>
+        dplyr::group_by(personal_id, organization_id) |>
+        # Keep first row per client
+        dplyr::filter(dplyr::row_number() == 1) |>
+        dplyr::ungroup()
 
-    )
+    })
 
-    # Render number of clients box
-    output$n_youth_box <- bs4Dash::renderbs4ValueBox({
+    n_youth_in_disability_data <- reactive({
+
+      disabilities_data_filtered() |>
+        dplyr::select(organization_id, personal_id) |>
+        dplyr::n_distinct()
+
+    })
+
+    # Render number of youth in disabilities data
+    output$n_youth_in_disability_data_box <- bs4Dash::renderbs4ValueBox({
 
       bs4Dash::bs4ValueBox(
-        value = n_youth(),
-        subtitle = "Total # of Youth in Program(s)",
+        value = n_youth_in_disability_data(),
+        subtitle = "Total # of Youth in Disabilities Data",
         icon = shiny::icon("user", class = "fa-solid")
       )
 
     })
 
-    # Render number of projects box
-    output$n_youth_with_disabilities_data_box <- bs4Dash::renderbs4ValueBox({
+    # Total number of youth with disabilities or substance use
+    n_youth_with_disabilities_or_substance_use <- shiny::reactive({
+
+      disabilities_data_recent() |>
+        dplyr::filter(
+          rowSums(
+            dplyr::across(
+              .cols = c(
+                `Physical Disability`,
+                `Developmental Disability`,
+                `Chronic Health Condition`,
+                `HIV/AIDS`,
+                `Mental Health Disorder`,
+                `Substance Use Disorder`
+              ),
+              .fns = function(value) value == "Yes"
+            )
+          ) > 0
+        ) |>
+        nrow()
+
+    })
+
+    # Render number of youth with disabilities or substance use box
+    output$n_youth_with_disabilities_or_substance_use_box <- bs4Dash::renderbs4ValueBox({
 
       bs4Dash::bs4ValueBox(
-        value = n_youth_with_disabilities_data(),
-        subtitle = "Total # of Youth with Disabilities Data Available",
+        value = n_youth_with_disabilities_or_substance_use(),
+        subtitle = "Total # of Youth with Disabilities or Substance Use",
         icon = shiny::icon("accessible-icon")
       )
 
     })
 
-    # Create reactive count of the number of youth with no disabilities
-    n_youth_with_no_disabilities <- shiny::reactive(
+    # Create reactive count of the number of youth without disabilities or substance use
+    # We are counting number of youth without a "Yes" in any column, so any missing data
+    # is counted as a "No"
+    n_youth_without_disabilities_or_substance_use <- shiny::reactive(
 
-      disabilities_data_filtered() |>
-        dplyr::distinct(organization_id, personal_id, disability_response) |>
-        dplyr::group_by(organization_id, personal_id) |>
-        dplyr::filter(dplyr::n() == 1L & disability_response == "No") |>
-        dplyr::ungroup() |>
-        nrow()
+      n_youth_in_disability_data() - n_youth_with_disabilities_or_substance_use()
 
     )
 
     # Render number of youth with no disabilities box
-    output$n_youth_with_no_disabilities_box <- bs4Dash::renderbs4ValueBox({
+    output$n_youth_without_disabilities_or_substance_use_box <- bs4Dash::renderbs4ValueBox({
 
       bs4Dash::bs4ValueBox(
-        value = n_youth_with_no_disabilities(),
-        subtitle = "Total # of Youth with No Disabilities or Substance Use",
+        value = n_youth_without_disabilities_or_substance_use(),
+        subtitle = "Total # of Youth without Informed Disabilities or Substance Use",
         icon = shiny::icon("accessible-icon")
       )
 
     })
 
-    # Pie Charts ----
+    # Charts ----
 
-    ## Disabilities Pie Chart ----
+    ## Disabilities Chart ----
 
-    # Create reactive data frame to data to be displayed in pie chart
-    disabilities_pie_chart_data <- shiny::reactive({
+    # Create reactive data frame to data to be displayed in chart
+    disabilities_chart_data <- shiny::reactive({
 
       shiny::validate(
         shiny::need(
-          expr = nrow(disabilities_data_filtered()) >= 1L,
+          expr = nrow(disabilities_data_recent()) >= 1L,
           message = "No data to display"
         )
       )
 
-      out <- disabilities_data_filtered() |>
-        dplyr::filter(disability_response == "Yes") |>
-        dplyr::arrange(
-          organization_id,
-          personal_id,
-          disability_type,
-          dplyr::desc(date_updated)
+      disabilities_data_recent() |>
+        # Remove Substance Use Disorder column
+        dplyr::select(-`Substance Use Disorder`) |>
+        # Each disability had its own column, we need data to be in long format
+        tidyr::pivot_longer(
+          cols = c(
+            `Physical Disability`,
+            `Developmental Disability`,
+            `Chronic Health Condition`,
+            `HIV/AIDS`,
+            `Mental Health Disorder`
+          ),
+          names_to = "Disability",
+          values_to = "Response"
         ) |>
-        dplyr::select(
-          organization_id,
-          personal_id,
-          disability_type,
-          disability_response
+        # We will consider NA values as "Data not collected"
+        tidyr::replace_na(list(Response = "Data not collected")) |>
+        dplyr::count(Disability, Response) |>
+        dplyr::group_by(Disability) |>
+        dplyr::mutate(pct = round(n / sum(n), 4)) |>
+        dplyr::ungroup() |>
+        # Order response categories
+        dplyr::mutate(
+          Response = factor(Response, levels = c("Yes",
+                                                 "No",
+                                                 "Data not collected",
+                                                 "Client doesn't know",
+                                                 "Client prefers not to answer"))
         ) |>
-        dplyr::distinct(
-          organization_id,
-          personal_id,
-          disability_type,
-          .keep_all = TRUE
-        )
-
-      shiny::validate(
-        shiny::need(
-          expr = nrow(out) >= 1L,
-          message = "No data to display"
-        )
-      )
-
-      out |>
-        dplyr::count(disability_type) |>
-        dplyr::arrange(disability_type)
+        dplyr::group_by(Response)
 
     })
 
-    # Create disabilities pie chart
-    output$disabilities_pie_chart <- echarts4r::renderEcharts4r({
+    # Create disabilities chart
+    output$disabilities_chart <- echarts4r::renderEcharts4r({
 
-      disabilities_pie_chart_data() |>
-        pie_chart(
-          category = "disability_type",
-          count = "n"
+      disabilities_chart_data() |>
+        echarts4r::e_chart(x = Disability) |>
+        echarts4r::e_bar(serie = n, stack = "my_stack") |>
+        echarts4r::e_add_nested('extra', pct) |>
+        echarts4r::e_flip_coords() |>
+        echarts4r::e_grid(containLabel = TRUE) |>
+        echarts4r::e_tooltip(formatter = htmlwidgets::JS("
+          function(params) {
+            return(
+              params.value[1] +
+              '<br/>' + params.marker + params.seriesName +
+              '<br/>' + '<strong>' + params.data.value[0] + ' (' + Math.round(params.data.extra.pct * 100) + '%)' + '</strong>'
+            )
+          }")
         )
 
     })
@@ -332,36 +387,11 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
         )
       )
 
-      out <- disabilities_data_filtered() |>
-        dplyr::filter(
-          disability_response %in% SubstanceUseDisorderCodes$Description[2:4]
-        ) |>
-        dplyr::arrange(
-          organization_id,
-          personal_id,
-          dplyr::desc(date_updated)
-        ) |>
-        dplyr::select(
-          organization_id,
-          personal_id,
-          disability_response
-        ) |>
-        dplyr::distinct(
-          organization_id,
-          personal_id,
-          .keep_all = TRUE
-        )
-
-      shiny::validate(
-        shiny::need(
-          expr = nrow(out) >= 1L,
-          message = "No data to display"
-        )
-      )
-
-      out |>
-        dplyr::count(disability_response) |>
-        dplyr::arrange(disability_response)
+      disabilities_data_recent() |>
+        dplyr::filter(`Substance Use Disorder` %in% SubstanceUseDisorderCodes$Description[2:4]) |>
+        dplyr::count(`Substance Use Disorder`) |>
+        # Match expected column name in chart
+        dplyr::rename(disability_response = "Substance Use Disorder")
 
     })
 


### PR DESCRIPTION
Changes were applied to Disabilities Page:

- InfoBoxes:
    - The first box contained the number of clients post filters. This number is the same in all pages, so I think is better to find a better way of showing this value (for example, in the navbar). I decided to show what we had in the second box in this position instead, but with a tweak: what is shown now is the number of youth in disability table, regardless of data quality (i.e. youth with "data not collected" entries in all disability columns is counted now). I think that this approach is better as it reflects what is entered in the .csv files. It can make ourselves question whether the data uploading is working as expected (for example, why for some clients the entry is not present but for others we have entries with "data not collected" values for all columns?)
    - The second box contained disabilities "Data Available". In the previous item I described how I moved this information to the first box and what tweak was applied. In this position I decided to show a "better" version of what we were showing in the third box: "number of youth with disabilities or substance use". In the new version, this number corresponds to youth that have a value of "Yes" in one of the columns that refer to disabilities or substance use. In case the youth has multiple entries, the most recent value will be used.
    - The third box contains the complement of the second box:, i.e. number of youth that did not inform any disabilities or substance use. The wording here is made on purpose to include both "No" and missing answers. In other words, we are counting all youth without a "Yes" value, regardless of missing data.

- Charts:
    - The first chart, which showed the "# of Youth with Disabilities by Type" was modified. In my opinion, the chart was "misleading". As we know, a person can have multiple disabilities at the same time. This chart wasn't taking that into account, and was placing all disabilities occurrences in the same bag. For that reason, the total number of "elements" did not match any of the totals in the infoboxes (as some youth were counted more than once). I decided to replace this chart with a bar chart that contains one bar per disability and shows the number/percentage of youth that have each particular disability. In other words, the chart now focuses on each disability one at a time and helps understanding the prevalence of each disability in the youth. However, this comes at the cost of not knowing how many people have multiple disabilities, i.e., the same youth can be part of multiple bars. Again, all answers are kept in order to understand how data looks. It is worth mentioning that we can quickly see that HIV/AIDS data is difficult to collect, as most entries are "Data not collected".
    - Code to generate the second chart was simplified, as now we are using the new auxiliar data that has "most recent values" per youth.

- Data Quality Statistics. This section was improved overall. New tabs were included that show different information:
    - We mention what percentage of "post filter youth" has entries in disabilities data
    - We show youth by number of answer missing. This refers to how many columns (remember that we have one column per disability / substance use) are data-less per youth. In this case, a youth with 6 answers missing is a youth that has "data not collected" in all entries (these youth were not counted as "data available" in the previous version of the infobox, now we can explore why this happened)
    - We show how many missing answers we have by disability. This can help focus on data collection on different responses.

General comments:
- We might need to think a better place to show the information showed in "Summary" tab of Data Quality Statistics.
- I'm still not convinced in showing information of Disabilities and Substance Use "combined" in the infoBoxes. Is it important to know people that have disabilities but no Substance use or viceversa?
- We need to revise the wording of the infoboxes. We are also planning on adding tooltips to provide additional context.
- Do we need to know people that said "No" in all entries? RIght now we don't show this information. Because one thing is saying "someone did not inform a Yes" (which is what we are showing now) and another thing is saying "someone said No to all entries". Right now, people that did not inform a Yes could actually be a Yes with missing data.

Closes #83 
