### PR TITLE
Fix disabilities chart

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,4 +45,4 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.2
+RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ryha
 Title: R Youth Homelessness Analyzer
-Version: 0.1.1
+Version: 1.1.1
 Authors@R: c(
     person("Michael", "Thomas", , "mthomas@ketchbrookanalytics.com", role = "aut"),
     person("Trevin", "Flickinger", , "trevinflickinger@cohhio.org", role = "cre")

--- a/R/mod_disabilities.R
+++ b/R/mod_disabilities.R
@@ -244,6 +244,8 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
     disabilities_data_recent <- shiny::reactive({
 
       disabilities_data_filtered() |>
+        # Remove duplicates from table
+        dplyr::distinct() |>
         # Unique key to identify a youth
         dplyr::group_by(personal_id, organization_id) |>
         # Keep the values that correspond to the last date_updated

--- a/R/mod_disabilities.R
+++ b/R/mod_disabilities.R
@@ -417,13 +417,22 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered){
 
       shiny::validate(
         shiny::need(
-          expr = nrow(disabilities_data_filtered()) >= 1L,
+          expr = nrow(disabilities_data_recent()) >= 1L,
           message = "No data to display"
         )
       )
 
-      disabilities_data_recent() |>
-        dplyr::filter(`Substance Use Disorder` %in% SubstanceUseDisorderCodes$Description[2:4]) |>
+      use_disorders_data <- disabilities_data_recent() |>
+        dplyr::filter(`Substance Use Disorder` %in% SubstanceUseDisorderCodes$Description[2:4])
+
+      shiny::validate(
+        shiny::need(
+          expr = nrow(use_disorders_data) >= 1L,
+          message = "No data to display"
+        )
+      )
+
+      use_disorders_data |>
         dplyr::count(`Substance Use Disorder`) |>
         # Match expected column name in chart
         dplyr::rename(disability_response = "Substance Use Disorder")

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.2.2",
+    "Version": "4.3.1",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -273,14 +273,14 @@
     },
     "cli": {
       "Package": "cli",
-      "Version": "3.4.1",
+      "Version": "3.6.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "0d297d01734d2bcea40197bd4971a764"
+      "Hash": "1216ac65ac55ec0058a6f75d7ca0fd52"
     },
     "clipr": {
       "Package": "clipr",
@@ -526,14 +526,14 @@
     },
     "fs": {
       "Package": "fs",
-      "Version": "1.5.2",
+      "Version": "1.6.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "7c89603d81793f0d5486d91ab1fc6f1d"
+      "Hash": "47b5f30c720c23999b913a1a635cf0bb"
     },
     "generics": {
       "Package": "generics",
@@ -613,14 +613,14 @@
     },
     "glue": {
       "Package": "glue",
-      "Version": "1.6.2",
+      "Version": "1.7.0",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "methods"
       ],
-      "Hash": "4f2596dfb05dac67b9dc558e5c6fba2e"
+      "Hash": "e0b3a53876554bd45879e596cdb10a52"
     },
     "golem": {
       "Package": "golem",
@@ -1080,15 +1080,18 @@
     },
     "purrr": {
       "Package": "purrr",
-      "Version": "0.3.5",
+      "Version": "1.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
+        "cli",
+        "lifecycle",
         "magrittr",
-        "rlang"
+        "rlang",
+        "vctrs"
       ],
-      "Hash": "54842a2443c76267152eface28d9e90a"
+      "Hash": "1cba04a4e9414bdefc9dcaa99649a8dc"
     },
     "rappdirs": {
       "Package": "rappdirs",
@@ -1160,18 +1163,18 @@
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "1.0.6",
+      "Version": "1.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R",
         "utils"
       ],
-      "Hash": "4ed1f8336c8d52c3e750adcdc57228a7"
+      "Hash": "42548638fae05fd9a9b5f3f437fbbbe2"
     },
     "roxygen2": {
       "Package": "roxygen2",
-      "Version": "7.2.2",
+      "Version": "7.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1182,7 +1185,6 @@
         "commonmark",
         "cpp11",
         "desc",
-        "digest",
         "knitr",
         "methods",
         "pkgload",
@@ -1194,7 +1196,7 @@
         "withr",
         "xml2"
       ],
-      "Hash": "d0dbb227bab26a4b8af658d81bfb6b36"
+      "Hash": "c25fe7b2d8cba73d1b63c947bf7afdb9"
     },
     "rprojroot": {
       "Package": "rprojroot",
@@ -1347,7 +1349,7 @@
     },
     "stringr": {
       "Package": "stringr",
-      "Version": "1.5.0",
+      "Version": "1.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1360,7 +1362,7 @@
         "stringi",
         "vctrs"
       ],
-      "Hash": "671a4d384ae9d32fc47a14e98bfa3dc8"
+      "Hash": "960e2ae9e09656611e0b8214ad543207"
     },
     "sys": {
       "Package": "sys",
@@ -1491,9 +1493,9 @@
     },
     "vctrs": {
       "Package": "vctrs",
-      "Version": "0.5.1",
+      "Version": "0.6.5",
       "Source": "Repository",
-      "Repository": "CRAN",
+      "Repository": "RSPM",
       "Requirements": [
         "R",
         "cli",
@@ -1501,7 +1503,7 @@
         "lifecycle",
         "rlang"
       ],
-      "Hash": "970324f6572b4fd81db507b5d4062cb0"
+      "Hash": "c03fa420630029418f7e6da3667aac4a"
     },
     "viridisLite": {
       "Package": "viridisLite",


### PR DESCRIPTION
Errors where found in some charts in Disabilities page.

**Prevalence Chart**. For some reason, some projects have duplicated data for youth. This caused a problem in the chart and was producing an error. The problem was solved by removing duplicates as a data wrangling step.

**Use Disorder Chart**. This chart uses only filtered records that have "use disorder" (i.e. it applies an additional layer of filters). When selected Projects have no youth with any *use disorder*, the resulting "new filtered" dataset has no rows and an error occurs. This was fixed by adding a middle `validate` step in the filtered data.

As part of this task, some packages were updated as well to avoid unexpected behavior.

Closes #92 