### PR TITLE
Fix tooltip overflow in destination chart

### DIFF
--- a/R/mod_living_situation.R
+++ b/R/mod_living_situation.R
@@ -364,6 +364,10 @@ mod_living_situation_server <- function(id, project_data, enrollment_data, exit_
             width = 350,
             overflow = "truncate"
           )
+        ) |>
+        echarts4r::e_tooltip(
+          confine = TRUE,
+          extraCssText = "width:auto; white-space:pre-wrap;"
         )
 
     })


### PR DESCRIPTION
To fix tooltip overflow in destination chart:
- Added [`confine = TRUE`](https://echarts.apache.org/en/option.html#tooltip.confine) to `echarts4r::e_tooltip()`. 
- Added some `extraCssText` (as recommended [here](https://github.com/apache/echarts/issues/16699#issuecomment-1137017011)) to wrap text automatically if the zoom level is too close for the `confine` to work as expected.

To test the task, launch the application and check the chart increasing the zoom level (you can try as much zoom as you want and it should work as expected).