### PR TITLE
Fix warnings that occur during data upload

### DIFF
--- a/R/utils_ingest.R
+++ b/R/utils_ingest.R
@@ -901,6 +901,7 @@ read_enrollment <- function(file) {
       ProjectID = readr::col_character(),
       EntryDate = readr::col_date(),
       HouseholdID = readr::col_character(),
+      EnrollmentCoC = readr::col_character(),
       DateToStreetESSH = readr::col_date(),
       MoveInDate = readr::col_date(),
       SexualOrientationOther = readr::col_character(),


### PR DESCRIPTION
# Overview
Uploading data to dev database produced warnings. The files that produced the warnings were:
- client
- enrollment
- project

**client** and **project** test files used introduce manual changes to obscure personal data and create mock organization and project ids. Saving those changes modify underlying data structure which causes certain dates to not be read properly in the app (**dob** in client and **operating_start_date** in project). As warnings do not happen when we use an unmodified version of the test file, they can be ignored. We could modify the way dates are parsed to accommodate for modified test files version. Let me know what you think!

**enrollment** warning was due to a column (**EnrollmentCoC**) being treated as numeric when in fact was character. I modified that accordingly. Currenytly, the column is not used in the application. If we were to need to use it, users would need to re-upload the data, as this column has been added as `NA` (due to the parsing problem).

# Test
Launch the application and try to upload a file. An unmodified file should throw no warnings. A modified file should throw only two warnings.
