### PR TITLE
Bug Fix: Blank services page

### DIFF
--- a/R/mod_services.R
+++ b/R/mod_services.R
@@ -119,10 +119,10 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
       shiny::updateDateRangeInput(
         session = session,
         inputId = "date_provided_filter",
-        start = min(services_data$date_provided),
-        end = max(services_data$date_provided),
-        min = min(services_data$date_provided),
-        max = max(services_data$date_provided)
+        start = min(services_data$date_provided, na.rm = TRUE),
+        end = max(services_data$date_provided, na.rm = TRUE),
+        min = min(services_data$date_provided, na.rm = TRUE),
+        max = max(services_data$date_provided, na.rm = TRUE)
       )
 
     })

--- a/inst/app/www/styles.css
+++ b/inst/app/www/styles.css
@@ -80,3 +80,8 @@ smaller screen widths */
   background-color: white;
   text-align: justify;
 }
+
+/* Bring datepicker to front */
+.datepicker {
+  z-index: 99999 !important;
+}


### PR DESCRIPTION
List of Changes:
- Added `na.rm = TRUE` when obtaining min and max dates for Date Provider Filter (Services Page). This way, `NA` values in the column will not make the app behave in an unexpected way.
- Added CSS to bring Date Picker to front.

Closes #113 