### PR TITLE
Update data dictionary link in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -96,7 +96,7 @@ The following requirements must be satisfied in order for the .zip file to be su
 
 ### Data Dictionary
 
-The data dictionary for each element across each file can be found [here](https://files.hudexchange.info/resources/documents/FY-2022-HMIS-Data-Dictionary.pdf). This data dictionary was used to develop the package datasets, which are created in [data-raw](data-raw) and stored in [data](data).
+The data dictionary for each element across each file can be found [here](https://files.hudexchange.info/resources/documents/HMIS-Data-Dictionary-2024.pdf). This data dictionary was used to develop the package datasets, which are created in [data-raw](data-raw) and stored in [data](data).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ to be successfully processed and its data written to the database:
 ### Data Dictionary
 
 The data dictionary for each element across each file can be found
-[here](https://files.hudexchange.info/resources/documents/FY-2022-HMIS-Data-Dictionary.pdf).
+[here](https://files.hudexchange.info/resources/documents/HMIS-Data-Dictionary-2024.pdf).
 This data dictionary was used to develop the package datasets, which are
 created in [data-raw](data-raw) and stored in [data](data).
 


### PR DESCRIPTION
Data dictionary link in README was outdated. It was pointing to 2022 data dictionary. Now it points to 2024 data dictionary.