### PR TITLE
Add deployment script

### DIFF
--- a/dev/03_deploy.R
+++ b/dev/03_deploy.R
@@ -27,19 +27,8 @@ devtools::build()
 
 ## RStudio ----
 ## If you want to deploy on RStudio related platforms
-golem::add_rstudioconnect_file()
 golem::add_shinyappsio_file()
-golem::add_shinyserver_file()
 
-## Docker ----
-## If you want to deploy via a generic Dockerfile
-golem::add_dockerfile()
-
-## If you want to deploy to ShinyProxy
-golem::add_dockerfile_shinyproxy()
-
-## If you want to deploy to Heroku
-golem::add_dockerfile_heroku()
 ## Deploy to Posit Connect or ShinyApps.io ----
 
 ## In command line:

--- a/dev/03_deploy.R
+++ b/dev/03_deploy.R
@@ -40,3 +40,26 @@ golem::add_dockerfile_shinyproxy()
 
 ## If you want to deploy to Heroku
 golem::add_dockerfile_heroku()
+## Deploy to Posit Connect or ShinyApps.io ----
+
+## In command line:
+rsconnect::deployApp(
+  appName = "cohhio-youth-data-dashboard",
+  appTitle = "COHHIO Youth Data Dashboard",
+  appFiles = c(
+    # Add any additional files unique to your app here.
+    "R/",
+    "inst/",
+    "data/",
+    "NAMESPACE",
+    "DESCRIPTION",
+    "app.R",
+    ".Renviron",
+    ".Rbuildignore",
+    "hkey.RDS"
+  ),
+  account = "ohiobalanceofstatecoc",
+  appId =  "7831250",
+  lint = FALSE,
+  forceUpdate = TRUE
+)


### PR DESCRIPTION
This PR adds code to deploy the application programmatically.

The code chunk should work when run inside a Dev Container.

It is expected that this change will make deployments more straightforward.

The `appId` was extracted from ShinyApps.io.

In addition, some unnecessary lines were removed from `dev/03_deploy.R` file.

Closes #116 