### PR TITLE
Handle missing referral source values

### DIFF
--- a/.devcontainer/install_dev_packages.R
+++ b/.devcontainer/install_dev_packages.R
@@ -4,7 +4,8 @@ renv::restore()
 # Install packages for development
 ## General use
 renv::install("devtools@2.4.3")
-renv::install("attachment")
+renv::install("tinytex@0.53")
+renv::install("attachment@0.4.1")
 
 ## VS Code specific
 renv::install("languageserver")

--- a/R/mod_services.R
+++ b/R/mod_services.R
@@ -260,7 +260,7 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
       referral_data_filtered() |>
         dplyr::mutate(
           referral_source = dplyr::case_when(
-            is.na(referral_source) ~ "(Blanks)",
+            is.na(referral_source) ~ "(Blank)",
             TRUE ~ referral_source
           )
         ) |>

--- a/R/mod_services.R
+++ b/R/mod_services.R
@@ -260,7 +260,7 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
       referral_data_filtered() |>
         dplyr::mutate(
           referral_source = dplyr::case_when(
-            is.na(referral_source) ~ "Missing (Blanks)",
+            is.na(referral_source) ~ "(Blanks)",
             TRUE ~ referral_source
           )
         ) |>

--- a/R/mod_services.R
+++ b/R/mod_services.R
@@ -258,7 +258,12 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
       )
 
       referral_data_filtered() |>
-        dplyr::filter(!is.na(referral_source)) |>
+        dplyr::mutate(
+          referral_source = dplyr::case_when(
+            is.na(referral_source) ~ "Missing (Blanks)",
+            TRUE ~ referral_source
+          )
+        ) |>
         dplyr::distinct(personal_id, organization_id, referral_source) |>
         dplyr::count(referral_source) |>
         dplyr::arrange(n)


### PR DESCRIPTION
The error shown in the "Services" page's chart after applying the following filter:

- Project == "SSO HCNWO Homeless Youth Project"
- Period == 2023-04-01 through 2023-06-30

is due to the presence of `NA` values in `referral_source` column for all filtered rows.

Our current logic shows the message "No data to display" when the filtered dataset has no rows. In this case, the data has rows, but the charted column is `NA` for all values.

It was decided to replace `NA` values with a `Missing (Blanks)` category. This way, we can learn from data that the column has missing values (and act on it, for example, if we shouldn't see missing values for the column).

Moreover, I think this is something we should note and apply throughout the app, as "Blanks" can be informative too (the same way as `Data not collected` and `Client prefers not to answer` categories). This could be implemented when data processing is reviewed as part of #120. Remember that in case a user does not want to see that particular category, they can always "de-select" the category from the chart.

Please feel free to share your thoughts! Also, if you have a better suggestion for the category name, let me know!

Closes #56 