### PR TITLE
Fix "# of Youth by Last Grade Completed Group" chart

### DIFF
--- a/R/mod_education.R
+++ b/R/mod_education.R
@@ -212,7 +212,7 @@ mod_education_server <- function(id, education_data, clients_filtered){
             last_grade_completed == "Grades 5-6" ~ "Grades 5-8",
             last_grade_completed == "Grades 7-8" ~ "Grades 5-8",
             last_grade_completed == "Grades 9-11" ~ "Grades 9-11",
-            last_grade_completed == "Grades 12 / High school diploma" ~ "High school diploma/GED",
+            last_grade_completed == "Grade 12 / High school diploma" ~ "High school diploma/GED",
             last_grade_completed == "School program does not have grade levels" ~ "Unknown",
             last_grade_completed == "GED" ~ "High school diploma/GED",
             last_grade_completed == "Some College" ~ "Some College",


### PR DESCRIPTION
"# of Youth by Last Grade Completed Group" chart was not correct: `"High school diploma/GED"` group had less observations than expected.

The problem was that we were assigning the label "Grades 12 / High school diploma" to the group, which didn't match a valid Last Grade Completed value. We needed to assign "Grade 12 / High school diploma" label instead.

Solving the issue consisted on just properly type the expected category name.