### PR TITLE
173 Fix tooltip cut off

### DIFF
--- a/R/fct_generate_charts.R
+++ b/R/fct_generate_charts.R
@@ -159,7 +159,11 @@ sankey_chart <- function(data,
             value = count,
             layoutIterations = 0
         ) |>
-        echarts4r::e_tooltip(trigger = "item") |>
+        echarts4r::e_tooltip(
+            trigger = "item",
+            confine = TRUE,
+            extraCssText = "width:auto; white-space:pre-wrap;"
+        ) |>
         echarts4r::e_color(color = color) |>
         echarts4r::e_grid(containLabel = TRUE)
 }

--- a/R/fct_generate_charts.R
+++ b/R/fct_generate_charts.R
@@ -109,7 +109,9 @@ add_stacked_bar_tooltip <- function(echart) {
           });
           tooltip += '</table>';
           return tooltip;
-        }")
+        }"),
+            confine = TRUE,
+            extraCssText = "width:auto; white-space:pre-wrap;"
         )
 }
 


### PR DESCRIPTION
Tooltip was cutting off outside the container in sankey and stacked bar charts.

To address the issue, I added `confine = TRUE` and `extraCssText = "width:auto; white-space:pre-wrap;"` to `add_stacked_bar_tooltip()` and `sankey_chart()`.

Closes #173 