### PR TITLE
175 Link sections to new Data Standards Manual

### DIFF
--- a/R/mod_overview.R
+++ b/R/mod_overview.R
@@ -26,7 +26,12 @@ mod_overview_ui <- function(id) {
         ),
         bslib::layout_columns(
             custom_card(
-                bslib::card_header("Participants by Sex"),
+                bslib::card_header(
+                    with_popover(
+                        text = "Participants by Sex",
+                        content = link_section("4.21 Sex")
+                    )
+                ),
                 echarts4r::echarts4rOutput(outputId = ns("sex_chart"), height = "100%")
             ),
             custom_card(

--- a/R/utils_ui.R
+++ b/R/utils_ui.R
@@ -144,7 +144,7 @@ link_section <- function(section) {
 #' @return An HTML anchor (`<a>`) tag as a `shiny.tag` object.
 #' @export
 link_data_standards_manual <- function() {
-    URL <- "https://cohhio.org/wp-content/uploads/2025/03/HMIS-Data-Standards-Manual-2024.pdf"
+    URL <- "https://files.hudexchange.info/resources/documents/HMIS-Data-Standards.pdf"
     shiny::tags$a(href = URL, target = "_blank", "HMIS Data Standards Manual")
 }
 


### PR DESCRIPTION
New Data Standards Manual has been posted to HUD's website.

# List of Changes

- URL used in `link_data_standards_manual()` has been updated accordingly.
- Link to Sex section has been added

# Discussion

Unfortunately, links to actual sections are still not working due to how the file has been structured.
