### PR TITLE
179 combine missing and data not collected

### DIFF
--- a/R/fct_create_dm.R
+++ b/R/fct_create_dm.R
@@ -311,7 +311,6 @@ create_dm <- function(env,
                 last_grade_completed_grouped = factor(
                     last_grade_completed,
                     levels = c(
-                        "Missing",
                         "Data not collected",
                         "Client prefers not to answer",
                         "Client doesn't know",
@@ -329,7 +328,6 @@ create_dm <- function(env,
                         "Vocational Degree"
                     ),
                     labels = c(
-                        "Missing",
                         "Data not collected",
                         "Client prefers not to answer",
                         "Client doesn't know",
@@ -351,7 +349,6 @@ create_dm <- function(env,
                 school_status = factor(
                     school_status,
                     levels = c(
-                        "Missing",
                         "Data not collected",
                         "Client prefers not to answer",
                         "Client doesn't know",
@@ -391,8 +388,7 @@ create_dm <- function(env,
                     dplyr::select(
                         description = Description,
                         living_situation_grouped = ExitCategory
-                    ) |>
-                    dplyr::bind_rows(c(description = "Missing", living_situation_grouped = "Missing")),
+                    ),
                 by = c("living_situation" = "description")
             ) |>
             dplyr::mutate(
@@ -444,8 +440,7 @@ create_dm <- function(env,
                                 "Poor",
                                 "Client doesn't know",
                                 "Client prefers not to answer",
-                                "Data not collected",
-                                "Missing"
+                                "Data not collected"
                             ),
                             ordered = TRUE
                         )
@@ -606,8 +601,7 @@ create_dm <- function(env,
                     dplyr::select(
                         description = Description,
                         destination_grouped = ExitCategory
-                    ) |>
-                    dplyr::bind_rows(c(description = "Missing", destination_grouped = "Missing")),
+                    ),
                 by = c("destination" = "description")
             ) |>
             dplyr::mutate(

--- a/R/fct_create_dm.R
+++ b/R/fct_create_dm.R
@@ -740,19 +740,28 @@ read_data_from_table <- function(connection, table_name, column_names) {
 #' Convert vector to ordered factor
 #'
 #' `convert_to_ordered_factor()` converts a vector to an ordered factor,
-#' ensuring that "Missing" appears as the first level, followed by the
-#' descriptions from a provided `codes` data frame in reverse order.
+#' ordering by reverse `Description` from the `codes` data frame.
+#' "Data not collected" is automatically prepended to the levels if it
+#' does not already exist in the codes.
 #'
 #' @param x A vector to be converted into an ordered factor.
 #' @param codes A data frame containing a column `Description` that defines
-#' the factor levels (excluding "Missing").
+#' the factor levels.
 #'
-#' @return An ordered factor with levels starting with "Missing" and followed
-#' by the reversed descriptions.
+#' @return An ordered factor with levels in reverse order from codes, with
+#' "Data not collected" prepended if not already present.
 convert_to_ordered_factor <- function(x, codes) {
-    factor(
-        x,
-        levels = c("Missing", rev(codes$Description)),
-        ordered = TRUE
-    )
+    if ("Data not collected" %in% codes$Description) {
+        factor(
+            x,
+            levels = c(rev(codes$Description)),
+            ordered = TRUE
+        )
+    } else {
+        factor(
+            x,
+            levels = c("Data not collected", rev(codes$Description)),
+            ordered = TRUE
+        )
+    }
 }

--- a/R/fct_create_dm.R
+++ b/R/fct_create_dm.R
@@ -158,11 +158,11 @@ create_dm <- function(env,
                     age >= 14 & age <= 17 ~ "14-17",
                     age >= 6 & age <= 13 ~ "6-13",
                     age >= 0 & age <= 5 ~ "0-5",
-                    TRUE ~ "Missing"
+                    TRUE ~ "Data not collected"
                 ),
                 age_grouped = factor(
                     age_grouped,
-                    levels = c("Missing", "0-5", "6-13", "14-17", "18-24", "25+")
+                    levels = c("Data not collected", "0-5", "6-13", "14-17", "18-24", "25+")
                 )
             ) |>
             dplyr::select(
@@ -223,11 +223,11 @@ create_dm <- function(env,
                     organization_id,
                     personal_id
                 ) |>
-                # "Missing" category needs to be assigned manually because data was longer pivot
+                # "Data not collected" category needs to be assigned manually because data was longer pivot
                 dplyr::mutate(
                     ethnicity = dplyr::if_else(
                         ethnicity == "race_none" | is.na(ethnicity),
-                        "Missing",
+                        "Data not collected",
                         stringr::str_replace_all(ethnicity, "_", " ") |> tools::toTitleCase()
                     )
                 ) |>
@@ -235,7 +235,7 @@ create_dm <- function(env,
                     ethnicity = factor(
                         ethnicity,
                         levels = c(
-                            "Missing",
+                            "Data not collected",
                             "White",
                             "Native Hi Pacific",
                             "Mid East n African",
@@ -245,7 +245,7 @@ create_dm <- function(env,
                             "Am Ind Ak Native"
                         ),
                         labels = c(
-                            "Missing",
+                            "Data not collected",
                             "White",
                             "Native Hawaiian or Pacific Islander",
                             "Middle Eastern or North African",
@@ -514,11 +514,11 @@ create_dm <- function(env,
                     total_monthly_income_integer > 3000L & total_monthly_income_integer <= 4000L ~ "$3,001-$4,000",
                     total_monthly_income_integer > 4000L & total_monthly_income_integer <= 5000L ~ "$4,001-$5,000",
                     total_monthly_income_integer > 5000L ~ "$5,001 or more",
-                    TRUE ~ "Missing"
+                    TRUE ~ "Data not collected"
                 ) |>
                     factor(
                         levels = c(
-                            "Missing",
+                            "Data not collected",
                             "No Income",
                             "$1-$500",
                             "$551-$1,000",
@@ -735,7 +735,7 @@ read_data_from_table <- function(connection, table_name, column_names) {
         dplyr::mutate(
             dplyr::across(
                 tidyselect::where(is.character),
-                ~ tidyr::replace_na(.x, "Missing")
+                ~ tidyr::replace_na(.x, "Data not collected")
             )
         )
 

--- a/R/fct_generate_charts.R
+++ b/R/fct_generate_charts.R
@@ -42,7 +42,6 @@ bar_chart <- function(data, x, y, serie_name = "# of Participants", pct_denomina
             dplyr::mutate(
                 color = dplyr::case_when(
                     .data[[x]] %in% c(
-                        "Missing",
                         "Data not collected",
                         "Client prefers not to answer",
                         "Client doesn't know"

--- a/R/mod_disabilities.R
+++ b/R/mod_disabilities.R
@@ -231,8 +231,8 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered) {
                     names_to = "Disability",
                     values_to = "Response"
                 ) |>
-                # We will consider NA values as "Missing"
-                tidyr::replace_na(list(Response = "Missing")) |>
+                # We will consider NA values as "Data not collected"
+                tidyr::replace_na(list(Response = "Data not collected")) |>
                 dplyr::mutate(
                     Response = factor(
                         Response,
@@ -279,7 +279,7 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered) {
         ## Substance Use Disorder ####
         output$substance_chart <- echarts4r::renderEcharts4r({
             most_recent_data_per_enrollment() |>
-                tidyr::replace_na(list(`Substance Use Disorder` = "Missing")) |>
+                tidyr::replace_na(list(`Substance Use Disorder` = "Data not collected")) |>
                 dplyr::mutate(
                     `Substance Use Disorder` = factor(
                         `Substance Use Disorder`,

--- a/R/mod_disabilities.R
+++ b/R/mod_disabilities.R
@@ -241,8 +241,7 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered) {
                             "No",
                             "Client doesn't know",
                             "Client prefers not to answer",
-                            "Data not collected",
-                            "Missing"
+                            "Data not collected"
                         ),
                         ordered = TRUE
                     )
@@ -269,8 +268,7 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered) {
                         palette$no_neutral, # "No",
                         palette$client_doesnt_know, # "Client doesn't know",
                         palette$client_prefers_not_to_answer, # "Client prefers not to answer",
-                        palette$data_not_collected, # "Data not collected",
-                        palette$missing # "Missing"
+                        palette$data_not_collected # "Data not collected"
                     )
                 ) |>
                 add_stacked_bar_tooltip()
@@ -284,7 +282,6 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered) {
                     `Substance Use Disorder` = factor(
                         `Substance Use Disorder`,
                         levels = c(
-                            "Missing",
                             "Data not collected",
                             "Client prefers not to answer",
                             "Client doesn't know",
@@ -294,7 +291,6 @@ mod_disabilities_server <- function(id, disabilities_data, clients_filtered) {
                             "Alcohol use disorder"
                         ),
                         labels = c(
-                            "Missing",
                             "Data not collected",
                             "Client prefers not to answer",
                             "Client doesn't know",

--- a/R/mod_health.R
+++ b/R/mod_health.R
@@ -192,8 +192,7 @@ mod_health_server <- function(id, health_data, counseling_data, clients_filtered
                         palette$poor, # "Poor",
                         palette$client_doesnt_know, # "Client doesn't know",
                         palette$client_prefers_not_to_answer, # "Client prefers not to answer",
-                        palette$data_not_collected, # "Data not collected",
-                        palette$missing # "Missing"
+                        palette$data_not_collected # "Data not collected"
                     )
                 ) |>
                 add_stacked_bar_tooltip()

--- a/man/convert_to_ordered_factor.Rd
+++ b/man/convert_to_ordered_factor.Rd
@@ -10,14 +10,15 @@ convert_to_ordered_factor(x, codes)
 \item{x}{A vector to be converted into an ordered factor.}
 
 \item{codes}{A data frame containing a column \code{Description} that defines
-the factor levels (excluding "Missing").}
+the factor levels.}
 }
 \value{
-An ordered factor with levels starting with "Missing" and followed
-by the reversed descriptions.
+An ordered factor with levels in reverse order from codes, with
+"Data not collected" prepended if not already present.
 }
 \description{
 \code{convert_to_ordered_factor()} converts a vector to an ordered factor,
-ensuring that "Missing" appears as the first level, followed by the
-descriptions from a provided \code{codes} data frame in reverse order.
+ordering by reverse \code{Description} from the \code{codes} data frame.
+"Data not collected" is automatically prepended to the levels if it
+does not already exist in the codes.
 }


### PR DESCRIPTION
# Overview

"Missing Data" section of the HMIS Data Standards Manual 2026 mentions that

> The HMIS Data Standards assume that fields for which data are not collected will be left 
blank (i.e., 'missing'). In situations where a system requires a response to all data fields 
before saving a record, the system must use a specific response category to indicate that 
data was not collected. In such cases, that response category must be treated as missing 
data for reporting purposes.  

At some point during development, we decided to show "Missing" (due to blanks) and "Data not collected" separately because we considered that it would provide additional information about the missing nature. However, we now believe that the distinction adds unnecessary complexity. For that reason, this PR combines "Missing" and "Data not collected" into a single "Data not collected" category.

# Details

- "Missing" instances that were manually defined were replaced by "Data not collected"
- Removed "Missing" from defined `levels` vectors
- Missing data is now replaced by "Data not collected" rather than "Missing"
- Refactored `convert_to_ordered_factor` to account for "Data not collected" replacement
- Removed any additional logic defined for "Missing" level 