### PR TITLE
182 handle duplicated disabilities_id

### DIFF
--- a/R/fct_create_dm.R
+++ b/R/fct_create_dm.R
@@ -728,7 +728,9 @@ read_data_from_table <- function(connection, table_name, column_names) {
         )
     ) |>
         # Convert to tibble
-        tibble::as_tibble()
+        tibble::as_tibble() |>
+        # Remove duplicated rows
+        dplyr::distinct()
 
     # Replace NA values
     data <- data |>


### PR DESCRIPTION
Charts in Disabilities Page were either showing an error (Disability Prevalence and Participants by Substance Use) or unexpected values (Changes in Disability Status).

The issue was related to unexpected duplicated records in `Disabilities.csv`.

The fix adds an additional de-duplication step to `read_data_from_table()`. This way, we also address any potential duplication in other files.