### PR TITLE
160 add charts to overview page

### DIFF
--- a/R/fct_create_dm.R
+++ b/R/fct_create_dm.R
@@ -411,6 +411,7 @@ create_dm <- function(env,
                         )
                     )
                 ),
+                relationship_to_ho_h = convert_to_ordered_factor(relationship_to_ho_h, RelationshipToHoHCodes),
                 former_ward_child_welfare = convert_to_ordered_factor(former_ward_child_welfare, NoYesReasonsForMissingDataCodes),
                 former_ward_juvenile_justice = convert_to_ordered_factor(former_ward_juvenile_justice, NoYesReasonsForMissingDataCodes)
             )

--- a/R/mod_overview.R
+++ b/R/mod_overview.R
@@ -70,6 +70,21 @@ mod_overview_ui <- function(id) {
         ),
         bslib::layout_columns(
             custom_card(
+                bslib::card_header("Households by Size"),
+                echarts4r::echarts4rOutput(outputId = ns("household_by_size_chart"), height = "100%")
+            ),
+            custom_card(
+                bslib::card_header(
+                    with_popover(
+                        text = "Participants by Relationship to Head of Household",
+                        content = link_section("3.15 Relationship to Head of Household")
+                    )
+                ),
+                echarts4r::echarts4rOutput(outputId = ns("relationship_to_ho_h_chart"), height = "100%")
+            )
+        ),
+        bslib::layout_columns(
+            custom_card(
                 bslib::card_header(
                     with_popover(
                         text = "Head of Household and/or Adults by Former Ward Child Welfare Response",
@@ -174,6 +189,36 @@ mod_overview_server <- function(id, client_data, enrollment_data, ethnicity_data
                     x = "ethnicity",
                     y = "n",
                     pct_denominator = nrow(clients_filtered())
+                )
+        })
+
+        ## Households by Size ####
+        output$household_by_size_chart <- echarts4r::renderEcharts4r({
+            enrollment_data_filtered() |>
+                dplyr::count(household_id) |>
+                dplyr::mutate(
+                    household_size = dplyr::case_when(
+                        n == 1 ~ "1 Person",
+                        n <= 4 ~ paste(n, "People"),
+                        n >= 5 ~ "5+ People"
+                    ) |>
+                        factor(levels = c("1 Person", paste(c("2", "3", "4", "5+"), "People")), ordered = TRUE)
+                ) |>
+                dplyr::count(household_size, .drop = FALSE) |>
+                bar_chart(
+                    x = "household_size",
+                    y = "n",
+                    serie_name = "# of Households with"
+                )
+        })
+
+        ## Relationship to Head of Household ####
+        output$relationship_to_ho_h_chart <- echarts4r::renderEcharts4r({
+            enrollment_data_filtered() |>
+                dplyr::count(relationship_to_ho_h, .drop = FALSE) |>
+                bar_chart(
+                    x = "relationship_to_ho_h",
+                    y = "n"
                 )
         })
 

--- a/R/mod_overview.R
+++ b/R/mod_overview.R
@@ -106,7 +106,11 @@ mod_overview_server <- function(id, client_data, enrollment_data, ethnicity_data
 
         ## Enrollment ####
         enrollment_data_filtered <- shiny::reactive({
-            filter_data(enrollment_data, clients_filtered()) |>
+            filter_data(enrollment_data, clients_filtered())
+        })
+
+        enrollment_hoh_adults_data_filtered <- shiny::reactive({
+            enrollment_data_filtered() |>
                 dplyr::semi_join(heads_of_household_and_adults_filtered(), by = c("enrollment_id", "personal_id", "organization_id"))
         })
 
@@ -118,13 +122,13 @@ mod_overview_server <- function(id, client_data, enrollment_data, ethnicity_data
 
         mod_value_box_server(
             id = "n_heads_of_household_and_adults",
-            rctv_data = enrollment_data_filtered
+            rctv_data = enrollment_hoh_adults_data_filtered
         )
 
         mod_value_box_server(
             id = "n_households",
             rctv_data = shiny::reactive({
-                filter_data(enrollment_data, clients_filtered()) |>
+                enrollment_data_filtered() |>
                     dplyr::distinct(household_id)
             })
         )
@@ -175,7 +179,7 @@ mod_overview_server <- function(id, client_data, enrollment_data, ethnicity_data
 
         ## Welfare ####
         output$welfare_chart <- echarts4r::renderEcharts4r(
-            enrollment_data_filtered() |>
+            enrollment_hoh_adults_data_filtered() |>
                 dplyr::count(former_ward_child_welfare, .drop = FALSE) |>
                 bar_chart(
                     x = "former_ward_child_welfare",
@@ -185,7 +189,7 @@ mod_overview_server <- function(id, client_data, enrollment_data, ethnicity_data
 
         ## Juvenile ####
         output$juvenile_chart <- echarts4r::renderEcharts4r(
-            enrollment_data_filtered() |>
+            enrollment_hoh_adults_data_filtered() |>
                 dplyr::count(former_ward_juvenile_justice, .drop = FALSE) |>
                 bar_chart(
                     x = "former_ward_juvenile_justice",


### PR DESCRIPTION
The following charts were added to the Overview page to improve understanding of household composition and support data quality checks:

- Households by Size. This chart provides a useful summary of household structures. It helps understand how households are distributed by size, which supports interpretation of program reach and planning.

- Participants by Relationship to Head of Household. This chart helps identify the composition of households by showing how youth are related to the head of household. It also serves as a data quality tool, allowing us to verify whether each household includes a single head of household.

You can check the new charts in the screenshot below:

<img width="1377" height="505" alt="image" src="https://github.com/user-attachments/assets/6095500d-2d65-4f79-af00-bfaa3c4a8e85" />
