### PR TITLE
184 edit referral source chart and move to overview

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -89,7 +89,6 @@ app_server <- function(input, output, session) {
         mod_services_server(
             id = "services_1",
             services_data = dm$services,
-            referral_data = dm$enrollment,
             clients_filtered = clients_filtered
         )
 

--- a/R/fct_create_dm.R
+++ b/R/fct_create_dm.R
@@ -412,6 +412,7 @@ create_dm <- function(env,
                     )
                 ),
                 relationship_to_ho_h = convert_to_ordered_factor(relationship_to_ho_h, RelationshipToHoHCodes),
+                referral_source = convert_to_ordered_factor(referral_source, ReferralSourceCodes),
                 former_ward_child_welfare = convert_to_ordered_factor(former_ward_child_welfare, NoYesReasonsForMissingDataCodes),
                 former_ward_juvenile_justice = convert_to_ordered_factor(former_ward_juvenile_justice, NoYesReasonsForMissingDataCodes)
             )

--- a/R/mod_overview.R
+++ b/R/mod_overview.R
@@ -102,6 +102,16 @@ mod_overview_ui <- function(id) {
                 ),
                 echarts4r::echarts4rOutput(outputId = ns("juvenile_chart"), height = "100%")
             )
+        ),
+        custom_card(
+            height = "720px",
+            bslib::card_header(
+                with_popover(
+                    text = "Head of Household and/or Adults by Referral Source",
+                    content = link_section("R1 Referral Source")
+                )
+            ),
+            echarts4r::echarts4rOutput(outputId = ns("referral_source_chart"), height = "100%")
         )
     )
 }
@@ -238,6 +248,16 @@ mod_overview_server <- function(id, client_data, enrollment_data, ethnicity_data
                 dplyr::count(former_ward_juvenile_justice, .drop = FALSE) |>
                 bar_chart(
                     x = "former_ward_juvenile_justice",
+                    y = "n"
+                )
+        )
+
+        ## Referral Source ####
+        output$referral_source_chart <- echarts4r::renderEcharts4r(
+            enrollment_hoh_adults_data_filtered() |>
+                dplyr::count(referral_source, .drop = FALSE) |>
+                bar_chart(
+                    x = "referral_source",
                     y = "n"
                 )
         )

--- a/R/mod_services.R
+++ b/R/mod_services.R
@@ -29,16 +29,6 @@ mod_services_ui <- function(id) {
                 )
             ),
             echarts4r::echarts4rOutput(outputId = ns("services_bar_chart"), height = "100%")
-        ),
-        custom_card(
-            height = "720px",
-            bslib::card_header(
-                with_popover(
-                    text = "Participants by Referral Source",
-                    content = link_section("R1 Referral Source")
-                )
-            ),
-            echarts4r::echarts4rOutput(outputId = ns("referral_bar_chart"), height = "100%")
         )
     )
 }
@@ -46,7 +36,7 @@ mod_services_ui <- function(id) {
 #' services Server Functions
 #'
 #' @noRd
-mod_services_server <- function(id, services_data, referral_data, clients_filtered) {
+mod_services_server <- function(id, services_data, clients_filtered) {
     moduleServer(id, function(input, output, session) {
         ns <- session$ns
 
@@ -83,22 +73,6 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
                 )
         )
 
-        # Apply the filters to the referral data
-        referral_data_filtered <- shiny::reactive({
-            shiny::req(services_data_filtered())
-
-            referral_data |>
-                dplyr::inner_join(
-                    services_data_filtered() |>
-                        dplyr::select(personal_id, organization_id),
-                    by = c("personal_id", "organization_id")
-                ) |>
-                dplyr::inner_join(
-                    clients_filtered(),
-                    by = c("personal_id", "organization_id", "enrollment_id")
-                )
-        })
-
         # Create reactive data frame to data to be displayed in bar chart
         services_bar_chart_data <- shiny::reactive({
             validate_data(services_data_filtered())
@@ -114,42 +88,6 @@ mod_services_server <- function(id, services_data, referral_data, clients_filter
         output$services_bar_chart <- echarts4r::renderEcharts4r({
             services_bar_chart_data() |>
                 echarts4r::e_charts(x = type_provided) |>
-                echarts4r::e_bar(
-                    serie = n,
-                    name = "Participants",
-                    legend = FALSE,
-                    label = list(
-                        formatter = "{@[0]}",
-                        show = TRUE,
-                        position = "right"
-                    )
-                ) |>
-                echarts4r::e_tooltip(trigger = "item") |>
-                echarts4r::e_flip_coords() |>
-                echarts4r::e_grid(containLabel = TRUE) |>
-                echarts4r::e_show_loading()
-        })
-
-        # Create reactive data frame to data to be displayed in bar chart
-        referral_bar_chart_data <- shiny::reactive({
-            validate_data(referral_data_filtered())
-
-            referral_data_filtered() |>
-                dplyr::mutate(
-                    referral_source = dplyr::case_when(
-                        is.na(referral_source) ~ "(Blank)",
-                        TRUE ~ referral_source
-                    )
-                ) |>
-                dplyr::distinct(personal_id, organization_id, referral_source) |>
-                dplyr::count(referral_source) |>
-                dplyr::arrange(n)
-        })
-
-        # Create referral source chart
-        output$referral_bar_chart <- echarts4r::renderEcharts4r({
-            referral_bar_chart_data() |>
-                echarts4r::e_charts(x = referral_source) |>
                 echarts4r::e_bar(
                     serie = n,
                     name = "Participants",


### PR DESCRIPTION
"Participants by Referral Source" chart was located in "Services" page and was affected by "Date Provided" selector.

HMIS Data Standards Manual defines that Referral Source data is collected about "Head of Households and Adults" at "Project start". We also noticed that Referral Source data was stored in `Enrollment.csv`.

Based on our findings, we decided to make the following changes:

- Move Referral Source chart to Overview and remove dependency on "Date Provided"
- Update chart data and title to Head of Households and Adults instead of Participants.
- Apply general chart improvements:
    - Use `bar_chart()` function to create the chart.
    - List all possible categories regardless of count. To do so, we needed to `convert_to_ordered_factor()` the `referral_source` column.

The following screenshot shows how the new chart looks:

<img width="1376" height="740" alt="image" src="https://github.com/user-attachments/assets/09039683-b210-432a-b87e-4cf0f989cb0d" />

