### PR TITLE
211 improve pkgdown site GitHub action

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,11 +32,15 @@ jobs:
           r-version: '4.4.3'
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-renv@v2
-
       - name: Install pak
         run: install.packages('pak', repos = 'https://r-lib.github.io/p/pak/stable/')
         shell: Rscript {0}
+
+      - name: Install renv
+        run: pak::pak('cran::renv@1.1.4')
+        shell: Rscript {0}
+
+      - uses: r-lib/actions/setup-renv@v2
 
       - name: Install pkgdown
         run: |

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,10 +31,19 @@ jobs:
         with:
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, local::.
-          needs: website
+      - uses: r-lib/actions/setup-renv@v2
+
+      - name: Install pak
+        run: install.packages('pak', repos = 'https://r-lib.github.io/p/pak/stable/')
+        shell: Rscript {0}
+
+      - name: Install pkgdown
+        run: pak::pkg_install("pkgdown@2.2.1", upgrade = FALSE, ask = FALSE)
+        shell: Rscript {0}
+
+      - name: Install package
+        run: install.packages(".", repos = NULL, type = "source", dependencies = FALSE)
+        shell: Rscript {0}
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -39,7 +39,14 @@ jobs:
         shell: Rscript {0}
 
       - name: Install pkgdown
-        run: pak::pkg_install("pkgdown@2.2.1", upgrade = FALSE, ask = FALSE)
+        run: |
+          # This repo's .Rprofile pins `repos` to a URL without the
+          # __linux__/<codename> segment, which serves source tarballs
+          # instead of binaries. Point back at the binary-serving RSPM
+          # URL that setup-r's use-public-rspm exported, so pak doesn't
+          # compile ragg/systemfonts/textshaping/xml2 from source.
+          options(repos = c(RSPM = Sys.getenv("RSPM")))
+          pak::pkg_install("pkgdown@2.2.1", upgrade = FALSE, ask = FALSE)
         shell: Rscript {0}
 
       - name: Install package

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -32,14 +32,6 @@ jobs:
           r-version: '4.4.3'
           use-public-rspm: true
 
-      - name: Install pak
-        run: install.packages('pak', repos = 'https://r-lib.github.io/p/pak/stable/')
-        shell: Rscript {0}
-
-      - name: Install renv
-        run: pak::pak('cran::renv@1.1.4')
-        shell: Rscript {0}
-
       - uses: r-lib/actions/setup-renv@v2
 
       - name: Install pkgdown

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -29,6 +29,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
+          r-version: '4.4.3'
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-renv@v2


### PR DESCRIPTION
## Speed up pkgdown.yaml by using a pinned renv.lock restore

### Why
`pkgdown.yaml` was taking ~10 minutes per run. Digging into the GitHub Actions run history showed that ~9 of those minutes were spent in the `setup-r-dependencies` step alone, reinstalling the full ~100-package dependency tree from scratch almost every run.

Root cause: that action lets `pak` resolve "latest available" versions for every dependency at run time. With no lockfile involved, any upstream package release (common across 100+ transitive deps) changes the resolved set, which invalidates the cache key and forces a from-scratch install — this was happening on nearly every run.

### What changed
Only `.github/workflows/pkgdown.yaml` is touched — `renv.lock`, `DESCRIPTION`, and `deploy.yaml` are untouched.

- Replaced `setup-r-dependencies` with `setup-renv@v2`, which restores the project's existing, pinned `renv.lock` — the same lockfile `deploy.yaml` already uses. Since the lockfile doesn't change on every run, the dependency cache now actually hits.
- Pinned R to `4.4.3` to match `renv.lock` (previously floated on "release", which also drifted).
- `pkgdown` itself isn't an app dependency, so it's not added to `renv.lock`/`DESCRIPTION` (that would leak docs-only packages into `deploy.yaml`'s restore). Instead it's installed in a separate step via `pak::pkg_install("pkgdown@2.2.1", upgrade = FALSE, ask = FALSE)`, pinned to an exact version, which only resolves pkgdown's own small dependency set without touching anything already restored.
- That install step also overrides `repos` to the `RSPM` binary-serving URL exported by `setup-r`'s `use-public-rspm`, before calling `pak`. This repo's `.Rprofile` pins `repos` to a Posit Package Manager URL without the `__linux__/<codename>` segment, which serves source tarballs instead of binaries — without the override, `pak` would compile packages like `ragg`, `systemfonts`, `textshaping`, and `xml2` from source on every run.
- Added an explicit local install step (`install.packages(".", repos = NULL, type = "source", dependencies = FALSE)`) — pkgdown's reference-page builder needs the package actually installed, not just loadable from source, even with `install = FALSE` on `build_site_github_pages()`.

### Impact
- `renv.lock` / `DESCRIPTION` / `deploy.yaml` are untouched — zero risk to the shinyapps.io deploy.
- Expect this workflow to drop from ~10 min to roughly 1-2 min per run.

### Notes for reviewers
- `pkgdown`'s pinned version (`2.2.1`) is hardcoded in the workflow — bump it manually there when a newer pkgdown is wanted.
- Verified locally end-to-end (fresh `renv::restore()` → install pak → install pinned pkgdown → install local package → `pkgdown::build_site_github_pages()`) before pushing.
